### PR TITLE
Issue 1626: Create a Docker image with Python and pip for use in the strongbox-web-integration-tests

### DIFF
--- a/images/alpine/Dockerfile.alpine
+++ b/images/alpine/Dockerfile.alpine
@@ -22,7 +22,7 @@ ENV HOME /home/jenkins
 ##
 
 ENV BASE_TOOLS bash bc ca-certificates curl coreutils file grep gnupg mc openssh-client openssh-keygen procps p7zip sed tar unzip wget xz jq
-ENV VCS_TOOLS git mercurial
+ENV VCS_TOOLS git
 ENV BUILD_DEPS dpkg dpkg-dev rpm rpm-dev
 ENV OTHER_DEPS libstdc++
 

--- a/images/alpine/jdk11/Dockerfile.alpine.jdk11-mvn3.6
+++ b/images/alpine/jdk11/Dockerfile.alpine.jdk11-mvn3.6
@@ -2,7 +2,7 @@ ARG SNAPSHOT=""
 FROM strongboxci/alpine:jdk11$SNAPSHOT
 
 ENV MVN_MAJOR_VERSION=3
-ENV MVN_VERSION=3.6.2
+ENV MVN_VERSION=3.6.3
 ENV M2_HOME="/java/mvn-${MVN_VERSION}"
 
 COPY common-scripts /scripts

--- a/images/alpine/jdk11/Dockerfile.alpine.jdk11-mvn3.6-pip19.3
+++ b/images/alpine/jdk11/Dockerfile.alpine.jdk11-mvn3.6-pip19.3
@@ -1,0 +1,49 @@
+ARG SNAPSHOT=""
+FROM strongboxci/alpine:jdk11-mvn3.6$SNAPSHOT
+
+USER root
+
+RUN set -ex \
+ && apk add --no-cache python3 \
+ && ln -s /usr/bin/python3 /usr/bin/python \
+ && rm -rf /tmp/*
+
+# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
+ENV PYTHON_PIP_VERSION 19.3.1
+# https://github.com/pypa/get-pip
+ENV PYTHON_GET_PIP_URL https://github.com/pypa/get-pip/raw/ffe826207a010164265d9cc807978e3604d18ca0/get-pip.py
+ENV PYTHON_GET_PIP_SHA256 b86f36cc4345ae87bfd4f10ef6b2dbfa7a872fbff70608a1e43944d283fd0eee
+
+RUN set -ex; \
+    \
+    wget -O get-pip.py "$PYTHON_GET_PIP_URL"; \
+    echo "$PYTHON_GET_PIP_SHA256 *get-pip.py" | sha256sum -c -; \
+    \
+    python get-pip.py \
+	--disable-pip-version-check \
+	--no-cache-dir \
+	"pip==$PYTHON_PIP_VERSION" \
+    ; \
+    pip --version; \
+    \
+    find /usr/local -depth \
+	\( \
+	    \( -type d -a \( -name test -o -name tests -o -name idle_test \) \) \
+	    -o \
+	    \( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
+	\) -exec rm -rf '{}' +; \
+    rm -f get-pip.py
+
+ONBUILD RUN virtualenv /env && /env/bin/pip install
+
+RUN set -ex \
+ && echo "Testing python installation" > /dev/null \
+ && python --version \
+ && python3 --version \
+ && echo "Testing pip installation" > /dev/null \
+ && pip --version
+
+USER jenkins
+
+CMD echo "" && mvn --version && echo "" && python3 --version && echo "" && pip --version && echo "" && /bin/bash
+

--- a/images/alpine/jdk8/Dockerfile.alpine.jdk8-mvn3.6
+++ b/images/alpine/jdk8/Dockerfile.alpine.jdk8-mvn3.6
@@ -2,7 +2,7 @@ ARG SNAPSHOT=""
 FROM strongboxci/alpine:jdk8$SNAPSHOT
 
 ENV MVN_MAJOR_VERSION=3
-ENV MVN_VERSION=3.6.2
+ENV MVN_VERSION=3.6.3
 ENV M2_HOME="/java/mvn-${MVN_VERSION}"
 
 COPY common-scripts /scripts

--- a/images/alpine/jdk8/Dockerfile.alpine.jdk8-mvn3.6-pip19.3
+++ b/images/alpine/jdk8/Dockerfile.alpine.jdk8-mvn3.6-pip19.3
@@ -1,0 +1,49 @@
+ARG SNAPSHOT=""
+FROM strongboxci/alpine:jdk8-mvn3.6$SNAPSHOT
+
+USER root
+
+RUN set -ex \
+ && apk add --no-cache python3 \
+ && ln -s /usr/bin/python3 /usr/bin/python \
+ && rm -rf /tmp/*
+
+# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
+ENV PYTHON_PIP_VERSION 19.3.1
+# https://github.com/pypa/get-pip
+ENV PYTHON_GET_PIP_URL https://github.com/pypa/get-pip/raw/ffe826207a010164265d9cc807978e3604d18ca0/get-pip.py
+ENV PYTHON_GET_PIP_SHA256 b86f36cc4345ae87bfd4f10ef6b2dbfa7a872fbff70608a1e43944d283fd0eee
+
+RUN set -ex; \
+    \
+    wget -O get-pip.py "$PYTHON_GET_PIP_URL"; \
+    echo "$PYTHON_GET_PIP_SHA256 *get-pip.py" | sha256sum -c -; \
+    \
+    python get-pip.py \
+	--disable-pip-version-check \
+	--no-cache-dir \
+	"pip==$PYTHON_PIP_VERSION" \
+    ; \
+    pip --version; \
+    \
+    find /usr/local -depth \
+	\( \
+	    \( -type d -a \( -name test -o -name tests -o -name idle_test \) \) \
+	    -o \
+	    \( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
+	\) -exec rm -rf '{}' +; \
+    rm -f get-pip.py
+
+ONBUILD RUN virtualenv /env && /env/bin/pip install
+
+RUN set -ex \
+ && echo "Testing python installation" > /dev/null \
+ && python --version \
+ && python3 --version \
+ && echo "Testing pip installation" > /dev/null \
+ && pip --version
+
+USER jenkins
+
+CMD echo "" && python3 --version && echo "" && pip --version && echo "" && /bin/bash
+

--- a/images/centos/jdk11/Dockerfile.centos.jdk11-mvn3.6
+++ b/images/centos/jdk11/Dockerfile.centos.jdk11-mvn3.6
@@ -2,7 +2,7 @@ ARG SNAPSHOT=""
 FROM strongboxci/centos:jdk11$SNAPSHOT
 
 ENV MVN_MAJOR_VERSION=3
-ENV MVN_VERSION=3.6.2
+ENV MVN_VERSION=3.6.3
 ENV M2_HOME="/java/mvn-${MVN_VERSION}"
 
 COPY common-scripts /scripts

--- a/images/centos/jdk8/Dockerfile.centos.jdk8-mvn3.6
+++ b/images/centos/jdk8/Dockerfile.centos.jdk8-mvn3.6
@@ -2,7 +2,7 @@ ARG SNAPSHOT=""
 FROM strongboxci/centos:jdk8$SNAPSHOT
 
 ENV MVN_MAJOR_VERSION=3
-ENV MVN_VERSION=3.6.2
+ENV MVN_VERSION=3.6.3
 ENV M2_HOME="/java/mvn-${MVN_VERSION}"
 
 COPY common-scripts /scripts

--- a/images/debian/jdk11/Dockerfile.debian.jdk11-mvn3.6
+++ b/images/debian/jdk11/Dockerfile.debian.jdk11-mvn3.6
@@ -2,7 +2,7 @@ ARG SNAPSHOT=""
 FROM strongboxci/debian:jdk11$SNAPSHOT
 
 ENV MVN_MAJOR_VERSION=3
-ENV MVN_VERSION=3.6.2
+ENV MVN_VERSION=3.6.3
 ENV M2_HOME="/java/mvn-${MVN_VERSION}"
 
 COPY common-scripts /scripts

--- a/images/debian/jdk8/Dockerfile.debian.jdk8-mvn3.6
+++ b/images/debian/jdk8/Dockerfile.debian.jdk8-mvn3.6
@@ -2,7 +2,7 @@ ARG SNAPSHOT=""
 FROM strongboxci/debian:jdk8$SNAPSHOT
 
 ENV MVN_MAJOR_VERSION=3
-ENV MVN_VERSION=3.6.2
+ENV MVN_VERSION=3.6.3
 ENV M2_HOME="/java/mvn-${MVN_VERSION}"
 
 COPY common-scripts /scripts

--- a/images/opensuse/jdk11/Dockerfile.opensuse.jdk11-mvn3.6
+++ b/images/opensuse/jdk11/Dockerfile.opensuse.jdk11-mvn3.6
@@ -2,7 +2,7 @@ ARG SNAPSHOT=""
 FROM strongboxci/opensuse:jdk11$SNAPSHOT
 
 ENV MVN_MAJOR_VERSION=3
-ENV MVN_VERSION=3.6.2
+ENV MVN_VERSION=3.6.3
 ENV M2_HOME="/java/mvn-${MVN_VERSION}"
 
 COPY common-scripts /scripts

--- a/images/opensuse/jdk8/Dockerfile.opensuse.jdk8-mvn3.6
+++ b/images/opensuse/jdk8/Dockerfile.opensuse.jdk8-mvn3.6
@@ -2,7 +2,7 @@ ARG SNAPSHOT=""
 FROM strongboxci/opensuse:jdk8$SNAPSHOT
 
 ENV MVN_MAJOR_VERSION=3
-ENV MVN_VERSION=3.6.2
+ENV MVN_VERSION=3.6.3
 ENV M2_HOME="/java/mvn-${MVN_VERSION}"
 
 COPY common-scripts /scripts

--- a/images/ubuntu/jdk11/Dockerfile.ubuntu.jdk11-mvn3.6
+++ b/images/ubuntu/jdk11/Dockerfile.ubuntu.jdk11-mvn3.6
@@ -2,7 +2,7 @@ ARG SNAPSHOT=""
 FROM strongboxci/ubuntu:jdk11$SNAPSHOT
 
 ENV MVN_MAJOR_VERSION=3
-ENV MVN_VERSION=3.6.2
+ENV MVN_VERSION=3.6.3
 ENV M2_HOME="/java/mvn-${MVN_VERSION}"
 
 COPY common-scripts /scripts

--- a/images/ubuntu/jdk8/Dockerfile.ubuntu.jdk8-mvn3.6
+++ b/images/ubuntu/jdk8/Dockerfile.ubuntu.jdk8-mvn3.6
@@ -2,7 +2,7 @@ ARG SNAPSHOT=""
 FROM strongboxci/ubuntu:jdk8$SNAPSHOT
 
 ENV MVN_MAJOR_VERSION=3
-ENV MVN_VERSION=3.6.2
+ENV MVN_VERSION=3.6.3
 ENV M2_HOME="/java/mvn-${MVN_VERSION}"
 
 COPY common-scripts /scripts


### PR DESCRIPTION
* Upgraded to Maven 3.6.3. Version 3.6.2 has regressions and has been removed from the public mirrors.
* Removed mercurial, because it depends on Python 2.x.
* Added a Dockerfile for Python 3.x and pip 19.3.

# Pull Request Description

This pull request closes strongbox/strongbox#1626.

# Acceptance Test

* [x] Running `./build.sh` successfully builds all images.

# Questions

* Does this pull request somehow break backward compatibility? 
  * [ ] Yes, it will require fixing build jobs.
  * [x] No

* Does this pull request require other pull requests to be merged first? 
  * [ ] Yes, please see #...
  * [x] No

* Does this require an update of the documentation?
  * [ ] Yes, please see strongbox/strongbox-docs#{PR_NUMBER}
  * [x] No
