### PR TITLE
Issue 1626: Create a Docker image with Python and pip for use in the strongbox-web-integration-tests

### DIFF
--- a/images/alpine/jdk8/Dockerfile.alpine.jdk8-mvn3.6-pip19.3
+++ b/images/alpine/jdk8/Dockerfile.alpine.jdk8-mvn3.6-pip19.3
@@ -36,7 +36,9 @@ RUN set -ex; \
 	    -o \
 	    \( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
 	\) -exec rm -rf '{}' +; \
-    rm -f get-pip.py
+    rm -f get-pip.py; \
+    mkdir -p `dirname $(pip --version | cut -f 4 -d " ")`; \
+    chown -R $USER_ID.$GROUP_ID $(dirname $(pip --version | cut -f 4 -d " "))
 
 RUN set -ex \
  && pip install twine \
@@ -48,7 +50,7 @@ RUN set -ex \
  && echo "Test twine installation" > /dev/null \
  && twine --version \
  && apk del twine-deps \
- && twine --version
+ && rm -rf /tmp/*
 
 USER jenkins
 


### PR DESCRIPTION
# Pull Request Description

This pull request closes strongbox/strongbox#1626

* Fixes permission issues.

# Acceptance Test

* [x] Running `./build.sh` successfully builds all images.

# Questions

* Does this pull request somehow break backward compatibility? 
  * [ ] Yes, it will require fixing build jobs.
  * [x] No

* Does this pull request require other pull requests to be merged first? 
  * [ ] Yes, please see #...
  * [x] No

* Does this require an update of the documentation?
  * [ ] Yes, please see strongbox/strongbox-docs#{PR_NUMBER}
  * [x] No
