### PR TITLE
Issue-1667: Update SBT to the appropriate 1.3 version

### DIFF
--- a/images/alpine/jdk8/Dockerfile.alpine.jdk8-mvn3.6-sbt1.3
+++ b/images/alpine/jdk8/Dockerfile.alpine.jdk8-mvn3.6-sbt1.3
@@ -1,7 +1,7 @@
 ARG SNAPSHOT=""
 FROM strongboxci/alpine:jdk8-mvn3.6$SNAPSHOT
 
-ENV SBT_VERSION=1.1.6
+ENV SBT_VERSION=1.3.7
 ENV SBT_HOME="/java/sbt-${SBT_VERSION}"
 
 COPY common-scripts /scripts


### PR DESCRIPTION
# Pull Request Description

This pull request closes strongbox/strongbox#1667

# Acceptance Test

* [x] Running `./build.sh` successfully builds all images.

# Questions

* Does this pull request somehow break backward compatibility? 
  * [x] Yes, it will require fixing build jobs
       * [As of 1.3, SBT uses Coursier instead of Ivy to resolve libraries](https://www.scala-sbt.org/1.x/docs/sbt-1.3-Release-Notes.html#Library+management+with+Coursier)
       * [This will break the integration test because Coursier is storing the artifacts in a different path](https://get-coursier.io/docs/cache), but it can be disabled temporarily using `ThisBuild / useCoursier := true`
  * [ ] No

* Does this pull request require other pull requests to be merged first? 
  * [ ] Yes, please see #...
  * [x] No

* Does this require an update of the documentation?
  * [ ] Yes, please see strongbox/strongbox-docs#{PR_NUMBER}
  * [x] No
