### PR TITLE
Issue-1667: Move SBT patch from the pipeline into the setup script to reduce complexity

### DIFF
--- a/common-scripts/setup-gradle.sh
+++ b/common-scripts/setup-gradle.sh
@@ -4,7 +4,9 @@ set -euxo pipefail
 
 mkdir -p $GRADLE_HOME $HOME/.gradle
 echo "Downloading https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip"
-curl -o /tmp/gradle-$GRADLE_VERSION.zip -L "https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip"
+# https://ec.haxx.se/usingcurl/usingcurl-timeouts
+# speed-limit is in bytes.
+curl --fail --speed-time 15 --speed-limit 1024000 -o /tmp/gradle-$GRADLE_VERSION.zip -L "https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip"
 unzip -d /java /tmp/gradle-$GRADLE_VERSION.zip
 ln -s $GRADLE_HOME/bin/* /usr/bin/
 chown ${USER_ID}.${GROUP_ID} $HOME/.gradle $GRADLE_HOME

--- a/common-scripts/setup-jdk.sh
+++ b/common-scripts/setup-jdk.sh
@@ -11,7 +11,9 @@ ln -s ${JAVA_HOME} /java/jdk
 
 # Downloading & Installing
 cd ${JAVA_HOME}
-curl --fail -O -J -L "${JDK_DW_URL}"
+# https://ec.haxx.se/usingcurl/usingcurl-timeouts
+# speed-limit is in bytes.
+curl --fail --speed-time 15 --speed-limit 1024000 -O -J -L "${JDK_DW_URL}"
 echo "${JDK_CHECKSUM} ${JDK_DW_FILENAME}" | sha256sum -c -
 7z l ${JDK_DW_FILENAME}
 7z x -y -snl ${JDK_DW_FILENAME}

--- a/common-scripts/setup-nuget.sh
+++ b/common-scripts/setup-nuget.sh
@@ -6,7 +6,9 @@ echo "Testing mono installation..." > /dev/null;
 mono --version
 
 echo "Installing nuget $NUGET_VERSION..." > /dev/null
-curl -j -L -o ${NUGET_PATH} "https://dist.nuget.org/win-x86-commandline/v${NUGET_VERSION}/nuget.exe"
+# https://ec.haxx.se/usingcurl/usingcurl-timeouts
+# speed-limit is in bytes.
+curl --fail --speed-time 15 --speed-limit 1024000 -j -L -o ${NUGET_PATH} "https://dist.nuget.org/win-x86-commandline/v${NUGET_VERSION}/nuget.exe"
 chmod +x ${NUGET_PATH}
 
 echo "Creating /etc/mono/registry with the right permissions" > /dev/null

--- a/common-scripts/setup-sbt.sh
+++ b/common-scripts/setup-sbt.sh
@@ -3,8 +3,24 @@
 set -euxo pipefail
 
 echo "Make dirs and fix permissions"
-mkdir -p $SBT_HOME/.sbt $HOME/.sbt
-chown -R $USER_ID.$GROUP_ID $SBT_HOME/.sbt $HOME/.sbt
+mkdir -p $SBT_HOME/.sbt $HOME/.sbt $HOME/.ivy2 $HOME/.cache
+chown -R $USER_ID.$GROUP_ID $SBT_HOME/.sbt $HOME/.sbt $HOME
 echo "Downloading https://github.com/sbt/sbt/releases/download/v$SBT_VERSION/sbt-$SBT_VERSION.tgz" > /dev/null
 curl -L -C - "https://github.com/sbt/sbt/releases/download/v$SBT_VERSION/sbt-$SBT_VERSION.tgz" | tar -xz --strip-components 1 -C ${SBT_HOME}
 ln -s $SBT_HOME/bin/* /usr/bin/
+
+# This is a special patch, which fixes some mysterious issue with SBT's bash script which is unable
+# to pick the environment variables for some unknown reason.
+# Removing this will result in the following build failure:
+#  gave the following error:
+#  [ERROR] /java/sbt-1.1.6/bin/sbt-launch-lib.bash: line 258: java: command not found
+#   mkdir: cannot create directory ??????: No such file or directory
+#   java/sbt-1.1.6/bin/sbt-launch-lib.bash: line 73: java: command not found
+#   java/sbt-1.1.6/bin/sbt-launch-lib.bash: line 73: java: command not found
+# OR something like
+#  gave the following error:
+#  [ERROR] /usr/bin/sbt: line 336: java: command not found
+#    mkdir: cannot create directory ??????: No such file or directory
+#    /usr/bin/sbt: line 343: java: command not found
+#    /usr/bin/sbt: line 127: exec: java: not found
+sed -i 's/^declare java_cmd=java/declare java_cmd=\/java\/jdk\/bin\/java/' /java/sbt-1.3.7/bin/sbt

--- a/common-scripts/setup-sbt.sh
+++ b/common-scripts/setup-sbt.sh
@@ -6,7 +6,9 @@ echo "Make dirs and fix permissions"
 mkdir -p $SBT_HOME/.sbt $HOME/.sbt $HOME/.ivy2 $HOME/.cache
 chown -R $USER_ID.$GROUP_ID $SBT_HOME/.sbt $HOME/.sbt $HOME
 echo "Downloading https://github.com/sbt/sbt/releases/download/v$SBT_VERSION/sbt-$SBT_VERSION.tgz" > /dev/null
-curl -L -C - "https://github.com/sbt/sbt/releases/download/v$SBT_VERSION/sbt-$SBT_VERSION.tgz" | tar -xz --strip-components 1 -C ${SBT_HOME}
+# https://ec.haxx.se/usingcurl/usingcurl-timeouts
+# speed-limit is in bytes.
+curl --fail --speed-time 15 --speed-limit 1024000 -L -C - "https://github.com/sbt/sbt/releases/download/v$SBT_VERSION/sbt-$SBT_VERSION.tgz" | tar -xz --strip-components 1 -C ${SBT_HOME}
 ln -s $SBT_HOME/bin/* /usr/bin/
 
 # This is a special patch, which fixes some mysterious issue with SBT's bash script which is unable

--- a/images/alpine/jdk11/Dockerfile.alpine.jdk11-mvn3.6-sbt1.3
+++ b/images/alpine/jdk11/Dockerfile.alpine.jdk11-mvn3.6-sbt1.3
@@ -1,7 +1,7 @@
 ARG SNAPSHOT=""
 FROM strongboxci/alpine:jdk11-mvn3.6$SNAPSHOT
 
-ENV SBT_VERSION=1.3.3
+ENV SBT_VERSION=1.3.7
 ENV SBT_HOME="/java/sbt-${SBT_VERSION}"
 
 COPY common-scripts /scripts


### PR DESCRIPTION
# Pull Request Description

This pull request is a follow-up to #6 

# Acceptance Test

* [x] Running `./build.sh` successfully builds all images.

# Questions

* Does this pull request somehow break backward compatibility? 
  * [x] Yes, it will require fixing build jobs.
  * [] No

* Does this pull request require other pull requests to be merged first? 
  * [ ] Yes, please see #...
  * [x] No

* Does this require an update of the documentation?
  * [ ] Yes, please see strongbox/strongbox-docs#{PR_NUMBER}
  * [x] No
