### PR TITLE
Issue-1905: Remove version on Nuget-related env variables

### DIFF
--- a/images/alpine/jdk11/Dockerfile.alpine.jdk11-mvn3.6-mono5-nuget3.4
+++ b/images/alpine/jdk11/Dockerfile.alpine.jdk11-mvn3.6-mono5-nuget3.4
@@ -6,9 +6,9 @@ ENV NUGET_VERSION=3.4.4
 ENV NUGET_PATH=/usr/local/bin/nuget-${NUGET_VERSION}.exe
 
 # S-W-I-T expects these environment variables to be set.
-ENV NUGET_V3_VERSION=$NUGET_VERSION
-ENV NUGET_V3_PATH=$NUGET_PATH
-ENV NUGET_V3_EXEC="mono ${NUGET_PATH}"
+ENV NUGET_VERSION=$NUGET_VERSION
+ENV NUGET_PATH=$NUGET_PATH
+ENV NUGET_EXEC="mono ${NUGET_PATH}"
 
 COPY common-scripts /scripts
 

--- a/images/alpine/jdk11/Dockerfile.alpine.jdk11-mvn3.6-mono5-nuget5.7
+++ b/images/alpine/jdk11/Dockerfile.alpine.jdk11-mvn3.6-mono5-nuget5.7
@@ -6,9 +6,9 @@ ENV NUGET_VERSION=5.7.0
 ENV NUGET_PATH=/usr/local/bin/nuget-${NUGET_VERSION}.exe
 
 # S-W-I-T expects these environment variables to be set.
-ENV NUGET_V3_VERSION=$NUGET_VERSION
-ENV NUGET_V3_PATH=$NUGET_PATH
-ENV NUGET_V3_EXEC="mono ${NUGET_PATH}"
+ENV NUGET_VERSION=$NUGET_VERSION
+ENV NUGET_PATH=$NUGET_PATH
+ENV NUGET_EXEC="mono ${NUGET_PATH}"
 
 COPY common-scripts /scripts
 

--- a/images/alpine/jdk8/Dockerfile.alpine.jdk8-mvn3.6-mono5-nuget3.4
+++ b/images/alpine/jdk8/Dockerfile.alpine.jdk8-mvn3.6-mono5-nuget3.4
@@ -6,9 +6,9 @@ ENV NUGET_VERSION=3.4.4
 ENV NUGET_PATH=/usr/local/bin/nuget-${NUGET_VERSION}.exe
 
 # S-W-I-T expects these environment variables to be set.
-ENV NUGET_V3_VERSION=$NUGET_VERSION
-ENV NUGET_V3_PATH=$NUGET_PATH
-ENV NUGET_V3_EXEC="mono ${NUGET_PATH}"
+ENV NUGET_VERSION=$NUGET_VERSION
+ENV NUGET_PATH=$NUGET_PATH
+ENV NUGET_EXEC="mono ${NUGET_PATH}"
 
 COPY common-scripts /scripts
 

--- a/images/alpine/jdk8/Dockerfile.alpine.jdk8-mvn3.6-mono5-nuget5.7
+++ b/images/alpine/jdk8/Dockerfile.alpine.jdk8-mvn3.6-mono5-nuget5.7
@@ -6,9 +6,9 @@ ENV NUGET_VERSION=5.7.0
 ENV NUGET_PATH=/usr/local/bin/nuget-${NUGET_VERSION}.exe
 
 # S-W-I-T expects these environment variables to be set.
-ENV NUGET_V3_VERSION=$NUGET_VERSION
-ENV NUGET_V3_PATH=$NUGET_PATH
-ENV NUGET_V3_EXEC="mono ${NUGET_PATH}"
+ENV NUGET_VERSION=$NUGET_VERSION
+ENV NUGET_PATH=$NUGET_PATH
+ENV NUGET_EXEC="mono ${NUGET_PATH}"
 
 COPY common-scripts /scripts
 


### PR DESCRIPTION
Necessary to allow for different major versions to be used without the
needing of code changes.

Refs #1905

# Pull Request Description

This pull request closes strongbox/strongbox#1905

# Acceptance Test

* [x] Running `./build.sh` successfully builds all images.

# Questions

* Does this pull request somehow break backward compatibility? 
  * [ ] Yes, it will require fixing build jobs.
  * [x] No

* Does this pull request require other pull requests to be merged first? 
  * [x] Yes, please see strongbox/strongbox-web-integration-tests#72
  * [ ] No

* Does this require an update of the documentation?
  * [ ] Yes, please see strongbox/strongbox-docs#{PR_NUMBER}
  * [x] No
