### PR TITLE
Issue 1957 Upgraded mkdocs-material docker image to the latest 6.1.4 …

### DIFF
--- a/images/mkdocs/Dockerfile.mkdocs
+++ b/images/mkdocs/Dockerfile.mkdocs
@@ -1,4 +1,4 @@
-FROM squidfunk/mkdocs-material:5.1.0
+FROM squidfunk/mkdocs-material:6.1.4
 
 # We are using this only for generating the documentations.
 RUN set -e -x \


### PR DESCRIPTION
Fixes strongbox/strongbox#1957

Needed for https://github.com/strongbox/strongbox-docs/pull/91